### PR TITLE
Feature/유저정보#97

### DIFF
--- a/src/main/java/com/example/web2_3_ourtuft_be/auth/dto/CustomOAuth2User.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/auth/dto/CustomOAuth2User.java
@@ -12,30 +12,30 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 @Getter
 public class CustomOAuth2User implements OAuth2User {
 
-  private final User user;
-  private final Map<String, Object> attributes;
+    private final User user;
+    private final Map<String, Object> attributes;
 
-  public CustomOAuth2User(User user, Map<String, Object> attributes) {
-    this.user = user;
-    this.attributes = attributes;
-  }
+    public CustomOAuth2User(User user, Map<String, Object> attributes) {
+        this.user = user;
+        this.attributes = attributes;
+    }
 
-  @Override
-  public Map<String, Object> getAttributes() {
-    return attributes;
-  }
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
 
-  @Override
-  public Collection<? extends GrantedAuthority> getAuthorities() {
-    return Collections.singletonList(new SimpleGrantedAuthority(user.getRole().name()));
-  }
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority(user.getRole()));
+    }
 
-  @Override
-  public String getName() {
-    return user.getName();
-  }
+    @Override
+    public String getName() {
+        return user.getName();
+    }
 
-  public String getSocialId() {
-    return user.getSocialId();
-  }
+    public String getSocialId() {
+        return user.getSocialId();
+    }
 }

--- a/src/main/java/com/example/web2_3_ourtuft_be/auth/dto/GoogleResponse.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/auth/dto/GoogleResponse.java
@@ -5,29 +5,29 @@ import java.util.Map;
 
 public class GoogleResponse implements OAuth2Response {
 
-  private final Map<String, Object> attributes;
+    private final Map<String, Object> attributes;
 
-  public GoogleResponse(Map<String, Object> attributes) {
-    this.attributes = attributes;
-  }
+    public GoogleResponse(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
 
-  @Override
-  public Provider getProvider() {
-    return Provider.GOOGLE;
-  }
+    @Override
+    public Provider getProvider() {
+        return Provider.GOOGLE;
+    }
 
-  @Override
-  public String getProviderId() {
-    return attributes.get("sub").toString();
-  }
+    @Override
+    public String getProviderId() {
+        return attributes.get("sub").toString();
+    }
 
-  @Override
-  public String getEmail() {
-    return attributes.get("email").toString();
-  }
+    @Override
+    public String getEmail() {
+        return attributes.get("email").toString();
+    }
 
-  @Override
-  public String getName() {
-    return attributes.get("name").toString();
-  }
+    @Override
+    public String getName() {
+        return attributes.get("name").toString();
+    }
 }

--- a/src/main/java/com/example/web2_3_ourtuft_be/auth/dto/KakaoResponse.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/auth/dto/KakaoResponse.java
@@ -5,33 +5,33 @@ import java.util.Map;
 
 public class KakaoResponse implements OAuth2Response {
 
-  private final Map<String, Object> attributes;
-  private final Map<String, Object> kakaoAccount;
-  private final Map<String, Object> profile;
+    private final Map<String, Object> attributes;
+    private final Map<String, Object> kakaoAccount;
+    private final Map<String, Object> profile;
 
-  public KakaoResponse(Map<String, Object> attributes) {
-    this.attributes = attributes;
-    this.kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
-    this.profile = (Map<String, Object>) kakaoAccount.get("profile");
-  }
+    public KakaoResponse(Map<String, Object> attributes) {
+        this.attributes = attributes;
+        this.kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        this.profile = (Map<String, Object>) kakaoAccount.get("profile");
+    }
 
-  @Override
-  public Provider getProvider() {
-    return Provider.KAKAO;
-  }
+    @Override
+    public Provider getProvider() {
+        return Provider.KAKAO;
+    }
 
-  @Override
-  public String getProviderId() {
-    return attributes.get("id").toString();
-  }
+    @Override
+    public String getProviderId() {
+        return attributes.get("id").toString();
+    }
 
-  @Override
-  public String getEmail() {
-    return kakaoAccount.get("email").toString();
-  }
+    @Override
+    public String getEmail() {
+        return kakaoAccount.get("email").toString();
+    }
 
-  @Override
-  public String getName() {
-    return profile.get("nickname").toString();
-  }
+    @Override
+    public String getName() {
+        return profile.get("nickname").toString();
+    }
 }

--- a/src/main/java/com/example/web2_3_ourtuft_be/auth/dto/OAuth2Response.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/auth/dto/OAuth2Response.java
@@ -4,11 +4,11 @@ import com.example.web2_3_ourtuft_be.user.entity.enums.Provider;
 
 public interface OAuth2Response {
 
-  Provider getProvider();
+    Provider getProvider();
 
-  String getProviderId();
+    String getProviderId();
 
-  String getEmail();
+    String getEmail();
 
-  String getName();
+    String getName();
 }

--- a/src/main/java/com/example/web2_3_ourtuft_be/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/auth/service/CustomOAuth2UserService.java
@@ -18,44 +18,44 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
-  private final UserRepository userRepository;
+    private final UserRepository userRepository;
 
-  @Override
-  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 
-    OAuth2User oAuth2User = super.loadUser(userRequest);
+        OAuth2User oAuth2User = super.loadUser(userRequest);
 
-    String provider = userRequest.getClientRegistration().getRegistrationId();
+        String provider = userRequest.getClientRegistration().getRegistrationId();
 
-    OAuth2Response oAuth2Response;
-    if (provider.equals("kakao")) {
-      oAuth2Response = new KakaoResponse(oAuth2User.getAttributes());
-    } else if (provider.equals("google")) {
-      oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
-    } else {
-      return null;
+        OAuth2Response oAuth2Response;
+        if (provider.equals("kakao")) {
+            oAuth2Response = new KakaoResponse(oAuth2User.getAttributes());
+        } else if (provider.equals("google")) {
+            oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
+        } else {
+            return null;
+        }
+
+        User user = findOrCreateUser(oAuth2Response);
+
+        return new CustomOAuth2User(user, oAuth2User.getAttributes());
     }
 
-    User user = findOrCreateUser(oAuth2Response);
+    private User findOrCreateUser(OAuth2Response oAuth2Response) {
+        User user = userRepository.findBySocialId(oAuth2Response.getProviderId()).orElse(null);
 
-    return new CustomOAuth2User(user, oAuth2User.getAttributes());
-  }
+        if (user == null) {
+            user =
+                    User.builder()
+                            .email(oAuth2Response.getEmail())
+                            .name(oAuth2Response.getName())
+                            .socialId(oAuth2Response.getProviderId())
+                            .provider(oAuth2Response.getProvider().toString())
+                            .role(Role.ROLE_USER.toString())
+                            .build();
+            userRepository.save(user);
+        }
 
-  private User findOrCreateUser(OAuth2Response oAuth2Response) {
-    User user = userRepository.findBySocialId(oAuth2Response.getProviderId()).orElse(null);
-
-    if (user == null) {
-      user =
-          User.builder()
-              .email(oAuth2Response.getEmail())
-              .name(oAuth2Response.getName())
-              .socialId(oAuth2Response.getProviderId())
-              .provider(oAuth2Response.getProvider().toString())
-              .role(Role.ROLE_USER.toString())
-              .build();
-      userRepository.save(user);
+        return user;
     }
-
-    return user;
-  }
 }

--- a/src/main/java/com/example/web2_3_ourtuft_be/global/exception/messages/DuplicatedMessages.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/global/exception/messages/DuplicatedMessages.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum DuplicatedMessages {
     NICKNAME("이미 등록된 닉네임입니다."),
     EMAIL("이미 등록된 이메일입니다."),
-    UNIQUE("UNIQUE 제약 조건 위배");
+    UNIQUE("UNIQUE 제약 조건 위배"),
+    CONFLICT("충돌 발생, 다시 시도해주세요");
 
     private final String message;
 }

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/controller/UserController.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/controller/UserController.java
@@ -1,10 +1,12 @@
 package com.example.web2_3_ourtuft_be.user.controller;
 
 import com.example.web2_3_ourtuft_be.global.response.GlobalResponse;
-import com.example.web2_3_ourtuft_be.user.dto.UserProfileResponseDto;
+import com.example.web2_3_ourtuft_be.user.dto.UserInfoResponseDto;
+import com.example.web2_3_ourtuft_be.user.service.UserFacadeService;
 import com.example.web2_3_ourtuft_be.user.service.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,15 +15,25 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserService userService;
+    private final UserFacadeService userFacadeService;
 
-    public UserController(UserService userService) {
+    public UserController(UserService userService, UserFacadeService userFacadeService) {
         this.userService = userService;
+        this.userFacadeService = userFacadeService;
     }
 
     @GetMapping("/myInfo")
-    public ResponseEntity<GlobalResponse<UserProfileResponseDto>> getMyProfile() {
+    public ResponseEntity<GlobalResponse<UserInfoResponseDto>> getMyProfile() {
 
-        UserProfileResponseDto response = userService.getMyPage();
+        UserInfoResponseDto response = userFacadeService.getMyInfo();
         return ResponseEntity.ok(GlobalResponse.success(response));
+    }
+
+    @GetMapping("/userInfo/{userId}")
+    public ResponseEntity<GlobalResponse<UserInfoResponseDto>> getUserInfo(
+            @PathVariable Long userId) {
+
+        UserInfoResponseDto responseDto = userFacadeService.getUserInfo(userId);
+        return ResponseEntity.ok(GlobalResponse.success(responseDto));
     }
 }

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/dto/NickNameColorItemDto.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/dto/NickNameColorItemDto.java
@@ -7,5 +7,5 @@ import lombok.Getter;
 @AllArgsConstructor
 public class NickNameColorItemDto {
     private Long itemId;
-    private String color;
+    private String value;
 }

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/dto/UserInfoResponseDto.java
@@ -1,27 +1,35 @@
 package com.example.web2_3_ourtuft_be.user.dto;
 
 import com.example.web2_3_ourtuft_be.user.entity.MemberProfile;
+import com.example.web2_3_ourtuft_be.user.entity.MemberRecord;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class UserProfileResponseDto {
+public class UserInfoResponseDto {
     private String nickname;
     private String introduction;
+    private int totalGames;
+    private int wins;
+    private double winRate;
     private ItemImageUrlDto eye;
     private ItemImageUrlDto mouth;
     private ItemImageUrlDto skin;
     private NickNameColorItemDto nickColor;
 
-    public UserProfileResponseDto(
+    public UserInfoResponseDto(
             MemberProfile memberProfile,
+            MemberRecord record,
             ItemImageUrlDto eye,
             ItemImageUrlDto mouth,
             ItemImageUrlDto skin,
             NickNameColorItemDto nickColor) {
         this.nickname = memberProfile.getNickname();
         this.introduction = memberProfile.getIntroduction();
+        this.totalGames = record.getTotalGames();
+        this.wins = record.getWinCount();
+        this.winRate = record.getWinRate();
         this.eye = eye;
         this.mouth = mouth;
         this.skin = skin;

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/entity/MemberProfile.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/entity/MemberProfile.java
@@ -6,7 +6,7 @@ import lombok.*;
 
 @Getter
 @Entity
-@Table
+@Table(name = "member_profiles")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/entity/MemberRecord.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/entity/MemberRecord.java
@@ -1,0 +1,40 @@
+package com.example.web2_3_ourtuft_be.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "member_records")
+public class MemberRecord {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "profile_id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    private int totalGames = 0;
+    private int winCount = 0;
+
+    @Version private int version;
+
+    public void increaseTotalGames() {
+        this.totalGames++;
+    }
+
+    public void increaseWinCount() {
+        this.winCount++;
+    }
+
+    public double getWinRate() {
+        if (totalGames == 0) {
+            return 0.0;
+        }
+        return Math.round(((double) winCount / totalGames) * 10000) / 100.0;
+    }
+}

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/entity/User.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/entity/User.java
@@ -1,8 +1,6 @@
 package com.example.web2_3_ourtuft_be.user.entity;
 
 import com.example.web2_3_ourtuft_be.common.BaseTime;
-import com.example.web2_3_ourtuft_be.user.entity.enums.Provider;
-import com.example.web2_3_ourtuft_be.user.entity.enums.Role;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/entity/enums/Provider.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/entity/enums/Provider.java
@@ -1,6 +1,6 @@
 package com.example.web2_3_ourtuft_be.user.entity.enums;
 
 public enum Provider {
-  KAKAO,
-  GOOGLE
+    KAKAO,
+    GOOGLE
 }

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/repository/MemberRecordRepository.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/repository/MemberRecordRepository.java
@@ -1,0 +1,12 @@
+package com.example.web2_3_ourtuft_be.user.repository;
+
+import com.example.web2_3_ourtuft_be.user.entity.MemberRecord;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRecordRepository extends JpaRepository<MemberRecord, Long> {
+
+    Optional<MemberRecord> findByUserId(Long userId);
+}

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/repository/UserRepository.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/repository/UserRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-  Optional<User> findBySocialId(String SocialId);
+    Optional<User> findBySocialId(String SocialId);
 }

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/service/MemberProfileService.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/service/MemberProfileService.java
@@ -1,0 +1,21 @@
+package com.example.web2_3_ourtuft_be.user.service;
+
+import com.example.web2_3_ourtuft_be.global.exception.exceptions.NotFoundException;
+import com.example.web2_3_ourtuft_be.global.exception.messages.NotFoundMessages;
+import com.example.web2_3_ourtuft_be.user.entity.MemberProfile;
+import com.example.web2_3_ourtuft_be.user.repository.MemberProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberProfileService {
+
+    private final MemberProfileRepository profileRepository;
+
+    public MemberProfile getMemberProfile(Long userId) {
+        return profileRepository
+                .findById(userId)
+                .orElseThrow(() -> new NotFoundException(NotFoundMessages.USER));
+    }
+}

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/service/MemberRecordService.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/service/MemberRecordService.java
@@ -1,0 +1,45 @@
+package com.example.web2_3_ourtuft_be.user.service;
+
+import com.example.web2_3_ourtuft_be.global.exception.exceptions.DuplicatedException;
+import com.example.web2_3_ourtuft_be.global.exception.exceptions.NotFoundException;
+import com.example.web2_3_ourtuft_be.global.exception.messages.DuplicatedMessages;
+import com.example.web2_3_ourtuft_be.global.exception.messages.NotFoundMessages;
+import com.example.web2_3_ourtuft_be.user.entity.MemberRecord;
+import com.example.web2_3_ourtuft_be.user.repository.MemberRecordRepository;
+import jakarta.persistence.OptimisticLockException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberRecordService {
+
+    private final MemberRecordRepository memberRecordRepository;
+
+    @Transactional
+    public void updateRecord(Long userId, boolean isWin) {
+        try {
+            MemberRecord record =
+                    memberRecordRepository
+                            .findById(userId)
+                            .orElseThrow(() -> new NotFoundException(NotFoundMessages.USER));
+
+            record.increaseTotalGames();
+            if (isWin) {
+                record.increaseWinCount();
+            }
+
+            memberRecordRepository.save(record);
+        } catch (OptimisticLockException e) {
+            // 충돌을 잡지 않는다면 아무일도 일어나지 않음, 즉, 사용자는 알 수 없음. 이거 더 좋을수도?
+            throw new DuplicatedException(DuplicatedMessages.CONFLICT);
+        }
+    }
+
+    public MemberRecord getRecord(Long userId) {
+        return memberRecordRepository
+                .findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException(NotFoundMessages.USER));
+    }
+}

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/service/UserFacadeService.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/service/UserFacadeService.java
@@ -1,0 +1,49 @@
+package com.example.web2_3_ourtuft_be.user.service;
+
+import com.example.web2_3_ourtuft_be.user.dto.ItemImageUrlDto;
+import com.example.web2_3_ourtuft_be.user.dto.NickNameColorItemDto;
+import com.example.web2_3_ourtuft_be.user.dto.UserInfoResponseDto;
+import com.example.web2_3_ourtuft_be.user.entity.MemberProfile;
+import com.example.web2_3_ourtuft_be.user.entity.MemberRecord;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserFacadeService {
+    private final MemberProfileService profileService;
+    private final MemberRecordService recordService;
+
+    @Transactional(readOnly = true)
+    public UserInfoResponseDto getUserInfo(Long userId) {
+
+        MemberProfile profile = profileService.getMemberProfile(userId);
+        MemberRecord record = recordService.getRecord(userId);
+        // TODO: Item 생성 후 처리
+        ItemImageUrlDto eye = new ItemImageUrlDto(profile.getEyeItemId(), "1");
+        ItemImageUrlDto mouse = new ItemImageUrlDto(profile.getMouseItemId(), "2");
+        ItemImageUrlDto skin = new ItemImageUrlDto(profile.getSkinItemId(), "3");
+        NickNameColorItemDto nickColor =
+                new NickNameColorItemDto(profile.getNicknameItemId(), "#123456");
+
+        return new UserInfoResponseDto(profile, record, eye, mouse, skin, nickColor);
+    }
+
+    // TODO : 프로필 수정 MyInfo 관련 entity 생성이 다 끝나고 나면 중복 제거 예정
+    @Transactional(readOnly = true)
+    public UserInfoResponseDto getMyInfo() {
+        // TODO: userId SecurityHolder 에서 가져옴
+        Long userId = 1L;
+        MemberProfile profile = profileService.getMemberProfile(userId);
+        MemberRecord record = recordService.getRecord(userId);
+        // TODO: Item 생성 후 처리
+        ItemImageUrlDto eye = new ItemImageUrlDto(profile.getEyeItemId(), "1");
+        ItemImageUrlDto mouse = new ItemImageUrlDto(profile.getMouseItemId(), "2");
+        ItemImageUrlDto skin = new ItemImageUrlDto(profile.getSkinItemId(), "3");
+        NickNameColorItemDto nickColor =
+                new NickNameColorItemDto(profile.getNicknameItemId(), "#123456");
+
+        return new UserInfoResponseDto(profile, record, eye, mouse, skin, nickColor);
+    }
+}

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/service/UserService.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/service/UserService.java
@@ -1,38 +1,9 @@
 package com.example.web2_3_ourtuft_be.user.service;
 
-import com.example.web2_3_ourtuft_be.global.exception.exceptions.NotFoundException;
-import com.example.web2_3_ourtuft_be.global.exception.messages.NotFoundMessages;
-import com.example.web2_3_ourtuft_be.user.dto.ItemImageUrlDto;
-import com.example.web2_3_ourtuft_be.user.dto.NickNameColorItemDto;
-import com.example.web2_3_ourtuft_be.user.dto.UserProfileResponseDto;
-import com.example.web2_3_ourtuft_be.user.entity.MemberProfile;
-import com.example.web2_3_ourtuft_be.user.repository.MemberProfileRepository;
-import com.example.web2_3_ourtuft_be.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
-
-    private final UserRepository userRepository;
-    private final MemberProfileRepository memberProfileRepository;
-
-    public UserProfileResponseDto getMyPage() {
-        // TODO: 추후 시큐리티 설정시 auth 에서 userId 가져오는 것으로 변경
-        Long userId = 1L;
-        MemberProfile profile =
-                memberProfileRepository
-                        .findByUserId(userId)
-                        .orElseThrow(() -> new NotFoundException(NotFoundMessages.USER));
-        // TODO: 아이템 도메인 생성 후, 장착 아이템 id로 부터 imageUrl 조회하여 담는 것으로 변경
-        ItemImageUrlDto eye = new ItemImageUrlDto(profile.getEyeItemId(), "1");
-        ItemImageUrlDto mouse = new ItemImageUrlDto(profile.getMouseItemId(), "2");
-        ItemImageUrlDto skin = new ItemImageUrlDto(profile.getSkinItemId(), "3");
-        // TODO: FE api 명세 피드백에 따라 데이터 변경 예정 (예: rgb 값, 색이름...)
-        NickNameColorItemDto nickColor =
-                new NickNameColorItemDto(profile.getNicknameItemId(), "red");
-
-        return new UserProfileResponseDto(profile, eye, mouse, skin, nickColor);
-    }
 }


### PR DESCRIPTION
# Pull Request Template

## 📝 PR 설명

- 유저 전적 엔티티 생성
- 유저 정보 조회 기능 구현
- 기존 마이페이지 조회와 유저 정보 조회의 경우 보유 아이템 목록 여부와 userId를 받는가 안받는가 차이가 있을것 같습니다.
- 유저 관련 테이블들이 추가되면서 기존 마이페이지 조회 수정
- 메서드 명과 필드 명 변경
- 유저 전적의 경우 낙관적 락을 사용하여 동시성 문제를 해결해보려고 합니다 (정상적인 경우 발생하지 않는 상황-같은 아이디로 동시에 여러 게임 진행, 게임 종료 후 갱신 요청이 반복해서 오는경우 등..), 추후 진행 예정 (후순위)



## 🔍 주요 변경사항

- [ ] UserFacadeService - 유저 테이블이 증가하면서 서비스간 호출을 지양하고 순환참조를 막기위해 도입
- [ ] MemberRecord - 유저 전적
- [ ] 코드컨벤션 적용 안된 파일들 적용


## 🧪 테스트

- [ ] 단위 테스트 추가/수정
- [ ] 테스트 커버리지 확인

## ✅ 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 코드나 주석이 없나요?
- [ ] 브랜치 네이밍 컨벤션을 따랐나요?
- [ ] 관련 문서를 업데이트했나요?

## 🤝 관련 테스트

- #97