### PR TITLE
Feature/#239 room status,participants

### DIFF
--- a/src/main/java/com/example/web2_3_ourtuft_be/room/redis/entity/RoomStatus.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/room/redis/entity/RoomStatus.java
@@ -1,0 +1,24 @@
+package com.example.web2_3_ourtuft_be.room.redis.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@RedisHash(value = "room:status")
+@Getter
+public class RoomStatus {
+
+    @Id private Long roomId;
+    private String status;
+
+    public void updateStatus(String status) {
+        this.status = status;
+    }
+
+    @Builder
+    public RoomStatus(Long roomId, String status) {
+        this.roomId = roomId;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/example/web2_3_ourtuft_be/room/redis/repository/RoomStatusRedisRepository.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/room/redis/repository/RoomStatusRedisRepository.java
@@ -1,0 +1,7 @@
+package com.example.web2_3_ourtuft_be.room.redis.repository;
+
+import com.example.web2_3_ourtuft_be.room.redis.entity.RoomStatus;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RoomStatusRedisRepository extends CrudRepository<RoomStatus, Long> {
+}

--- a/src/main/java/com/example/web2_3_ourtuft_be/room/redis/repository/RoomStatusRedisRepository.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/room/redis/repository/RoomStatusRedisRepository.java
@@ -3,5 +3,4 @@ package com.example.web2_3_ourtuft_be.room.redis.repository;
 import com.example.web2_3_ourtuft_be.room.redis.entity.RoomStatus;
 import org.springframework.data.repository.CrudRepository;
 
-public interface RoomStatusRedisRepository extends CrudRepository<RoomStatus, Long> {
-}
+public interface RoomStatusRedisRepository extends CrudRepository<RoomStatus, Long> {}

--- a/src/main/java/com/example/web2_3_ourtuft_be/room/redis/service/ParticipantService.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/room/redis/service/ParticipantService.java
@@ -1,0 +1,64 @@
+package com.example.web2_3_ourtuft_be.room.redis.service;
+
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ParticipantService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public String getParticipantsKey(Long roomId) {
+        return "room:participants:" + roomId;
+    }
+
+    public String getReadyStatusKey(Long roomId) {
+        return "room:readystatus:" + roomId;
+    }
+
+    public String getScoreKey(Long roomId) {
+        return "room:score:" + roomId;
+    }
+
+    public Long getTimeStamp() {
+        return System.currentTimeMillis();
+    }
+
+    // 플레이어 추가 (입장 순서와 준비 상태)
+    public void addParticipant(Long roomId, Long playerId) {
+
+        String participantsKey = getParticipantsKey(roomId);
+
+        redisTemplate
+                .opsForZSet()
+                .add(participantsKey, playerId, getTimeStamp()); // 타임스탬프로 입장 순서 관리
+        redisTemplate
+                .opsForHash()
+                .put(getReadyStatusKey(roomId), playerId, false); // 입장시 준비 상태 false
+    }
+
+    // 플레이어 준비 상태 토글
+    public void togglePlayerReady(Long roomId, Long playerId) {
+        String key = getReadyStatusKey(roomId);
+
+        // 현재 상태 가져오기
+        Object currentStatus = redisTemplate.opsForHash().get(key, playerId);
+        boolean isReady = currentStatus != null && Boolean.parseBoolean(currentStatus.toString());
+
+        // 반대 상태로 변경
+        redisTemplate.opsForHash().put(key, playerId, !isReady);
+    }
+
+    // 방에 있는 참가자 리스트 조회
+    public List<String> getParticipants(Long roomId) {
+
+        String participantsKey = getParticipantsKey(roomId);
+        Set<Object> range = redisTemplate.opsForZSet().range(participantsKey, 0, -1);
+
+        return range.stream().map(String::valueOf).toList();
+    }
+}

--- a/src/main/java/com/example/web2_3_ourtuft_be/room/redis/service/RoomParticipantRedisService.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/room/redis/service/RoomParticipantRedisService.java
@@ -1,0 +1,51 @@
+package com.example.web2_3_ourtuft_be.room.redis.service;
+
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RoomParticipantRedisService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public Long getTimeStamp() {
+
+        return System.currentTimeMillis();
+    }
+
+    public void addParticipant(Long roomId, Long userId) {
+
+        String key = "room:participants:" + roomId;
+
+        redisTemplate.opsForZSet().add(key, userId, getTimeStamp());
+    }
+
+    public List<String> getParticipants(Long roomId) {
+        String key = "room:participants:" + roomId;
+
+        Set<Object> participants = redisTemplate.opsForZSet().range(key, 0, -1);
+
+        return participants.stream().map(String::valueOf).toList();
+    }
+
+    // 방장이 권한 위임 없이 나갔을 경우 권한 위임 (입장순)
+    public String getNextHost(Long roomId) {
+
+        String key = "room:participants:" + roomId;
+
+        Set<Object> participants = redisTemplate.opsForZSet().range(key, 0, 2);
+
+        return participants.isEmpty() ? null : (String) participants.iterator().next();
+    }
+
+    public void removeParticipant(Long roomId, Long userId) {
+
+        String key = "room:participants:" + roomId;
+
+        redisTemplate.opsForZSet().remove(key, userId);
+    }
+}

--- a/src/main/java/com/example/web2_3_ourtuft_be/room/redis/service/RoomQuizService.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/room/redis/service/RoomQuizService.java
@@ -1,0 +1,40 @@
+package com.example.web2_3_ourtuft_be.room.redis.service;
+
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RoomQuizService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private String getQuizSetKey(Long roomId) {
+        return "room:quizset:" + roomId;
+    }
+
+    private String getQuizzesKey(Long quizSetId) {
+        return "room:quizzes:" + quizSetId;
+    }
+
+    // 퀴즈 세트 설정
+    public void setQuizSet(Long roomId, Long quizSetId) {
+        redisTemplate.opsForValue().set(getQuizSetKey(roomId), quizSetId);
+    }
+
+    // 퀴즈 세트에 문제들 추가
+    public void setQuizzes(Long quizSetId, Map<String, String> quizzes) {
+        String quizzesKey = getQuizzesKey(quizSetId);
+        quizzes.forEach(
+                (question, answer) -> {
+                    redisTemplate.opsForList().rightPush(quizzesKey, question + ":" + answer);
+                });
+    }
+
+    // 퀴즈 세트 가져오기
+    public Long getQuizSet(Long roomId) {
+        return Long.parseLong(redisTemplate.opsForValue().get(getQuizSetKey(roomId)).toString());
+    }
+}

--- a/src/main/java/com/example/web2_3_ourtuft_be/room/redis/service/RoomStatusRedisService.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/room/redis/service/RoomStatusRedisService.java
@@ -24,7 +24,7 @@ public class RoomStatusRedisService {
         RoomStatus roomStatus =
                 roomStatusRedisRepository
                         .findById(roomId)
-                        .orElseThrow(() -> new NotFoundException(NotFoundMessages.COUPON));
+                        .orElseThrow(() -> new NotFoundException(NotFoundMessages.ROOM_ID));
 
         roomStatus.updateStatus(newStatus);
 

--- a/src/main/java/com/example/web2_3_ourtuft_be/room/redis/service/RoomStatusRedisService.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/room/redis/service/RoomStatusRedisService.java
@@ -1,0 +1,33 @@
+package com.example.web2_3_ourtuft_be.room.redis.service;
+
+import com.example.web2_3_ourtuft_be.global.exception.exceptions.NotFoundException;
+import com.example.web2_3_ourtuft_be.global.exception.messages.NotFoundMessages;
+import com.example.web2_3_ourtuft_be.room.redis.entity.RoomStatus;
+import com.example.web2_3_ourtuft_be.room.redis.repository.RoomStatusRedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RoomStatusRedisService {
+
+    private final RoomStatusRedisRepository roomStatusRedisRepository;
+
+    // 방생성시 RoomStatus를 Redis에 저장
+    public void saveRoomStatus(Long roomId, String status) {
+        RoomStatus roomStatus = RoomStatus.builder().roomId(roomId).status(status).build();
+        roomStatusRedisRepository.save(roomStatus);
+    }
+
+    // 게임 시작, 종료시 RoomStatus 변경
+    public RoomStatus updateRoomStatus(Long roomId, String newStatus) {
+        RoomStatus roomStatus =
+                roomStatusRedisRepository
+                        .findById(roomId)
+                        .orElseThrow(() -> new NotFoundException(NotFoundMessages.COUPON));
+
+        roomStatus.updateStatus(newStatus);
+
+        return roomStatusRedisRepository.save(roomStatus);
+    }
+}

--- a/src/test/java/com/example/web2_3_ourtuft_be/room/redis/service/ParticipantServiceTest.java
+++ b/src/test/java/com/example/web2_3_ourtuft_be/room/redis/service/ParticipantServiceTest.java
@@ -1,0 +1,127 @@
+package com.example.web2_3_ourtuft_be.room.redis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+class ParticipantServiceTest {
+
+    @Autowired private RedisTemplate<String, Object> redisTemplate;
+
+    @Autowired private ParticipantService participantService;
+
+    @AfterEach
+    void tearDown() {
+        Long roomId = 12345L;
+        String participnatRoomKey = "room:participants:" + roomId;
+        String readyStatusRoomKey = "room:readystatus:" + roomId;
+        redisTemplate.delete(participnatRoomKey);
+        redisTemplate.delete(readyStatusRoomKey);
+    }
+
+    @DisplayName("플레이어가 참여시 해당하는 participants key에 저장한다. 이때 정렬은 timestamp이다.")
+    @Test
+    void testAddParticipantWithTimeStamp() {
+        // given
+        Long roomId = 12345L;
+        Long playerId = 10L;
+        String participnatRoomKey = "room:participants:" + roomId;
+
+        // when
+        redisTemplate.opsForZSet().add(participnatRoomKey, playerId, System.currentTimeMillis());
+
+        // then
+        Set<Object> range = redisTemplate.opsForZSet().range(participnatRoomKey, 0, -1);
+        assertThat(range).size().isEqualTo(1);
+        assertThat(range.iterator().next()).isEqualTo(10);
+    }
+
+    @DisplayName("플레이어가 참여시 readystatus key에 준비상태 false로 저장한다. ")
+    @Test
+    void testAddReadyStatusWithFalse() {
+        // given
+        Long roomId = 12345L;
+        Long playerId = 10L;
+        String statusRoomKey = "room:readystatus:" + roomId;
+
+        // when
+        redisTemplate.opsForHash().put(statusRoomKey, playerId, false);
+
+        // then
+        Object o = redisTemplate.opsForHash().get(statusRoomKey, playerId);
+        assertFalse(Boolean.parseBoolean(o.toString()));
+    }
+
+    @DisplayName("플레이어 참여시 해당 room 플레이어 리스트, 준비상태 저장한다. ")
+    @Test
+    void testAddParticipant() {
+        // given
+        Long roomId = 12345L;
+        Long playerId = 10L;
+
+        // when
+        participantService.addParticipant(roomId, playerId);
+
+        // then
+        Set<Object> range =
+                redisTemplate
+                        .opsForZSet()
+                        .range(participantService.getParticipantsKey(roomId), 0, -1);
+        Object o =
+                redisTemplate
+                        .opsForHash()
+                        .get(participantService.getReadyStatusKey(roomId), playerId);
+        assertThat(range).size().isEqualTo(1);
+        assertFalse(Boolean.parseBoolean(o.toString()));
+    }
+
+    @DisplayName("플레이어 준비상태를 변경한다.")
+    @Test
+    void test() {
+        // given
+        Long roomId = 12345L;
+        Long playerId = 10L;
+        participantService.addParticipant(roomId, playerId);
+
+        // when
+        participantService.togglePlayerReady(roomId, playerId);
+
+        // then
+        Object o =
+                redisTemplate
+                        .opsForHash()
+                        .get(participantService.getReadyStatusKey(roomId), playerId);
+        assertTrue(Boolean.parseBoolean(o.toString()));
+    }
+
+    @DisplayName("방에 있는 참가자 리스트 조회")
+    @Test
+    void testGetParticipants() {
+        // given
+        Long roomId = 12345L;
+        String participnatRoomKey = "room:participants:" + roomId;
+
+        redisTemplate.opsForZSet().add(participnatRoomKey, 10, System.currentTimeMillis());
+        redisTemplate.opsForZSet().add(participnatRoomKey, 11, System.currentTimeMillis() + 1);
+        redisTemplate.opsForZSet().add(participnatRoomKey, 12, System.currentTimeMillis() + 2);
+        redisTemplate.opsForZSet().add(participnatRoomKey, 13, System.currentTimeMillis() + 3);
+
+        // when
+        List<String> participants = participantService.getParticipants(roomId);
+
+        // then
+        assertThat(participants.size()).isEqualTo(4);
+    }
+}

--- a/src/test/java/com/example/web2_3_ourtuft_be/room/redis/service/RoomParticipantRedisServiceTest.java
+++ b/src/test/java/com/example/web2_3_ourtuft_be/room/redis/service/RoomParticipantRedisServiceTest.java
@@ -1,0 +1,103 @@
+package com.example.web2_3_ourtuft_be.room.redis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+class RoomParticipantRedisServiceTest {
+
+    @Autowired private RedisTemplate<String, Object> redisTemplate;
+
+    @Autowired private RoomParticipantRedisService roomParticipantRedisService;
+
+    @AfterEach
+    void tearDown() {
+        String roomKey = "room:participants:12345";
+        redisTemplate.delete(roomKey);
+    }
+
+    Long getTimeStamp() {
+        return System.currentTimeMillis();
+    }
+
+    @DisplayName("roomId로 참여자 목록을 가져온다.")
+    @Test
+    void testGetParticipants() {
+        // given
+        Long roomId = 12345L;
+        String key = "room:participants:" + roomId;
+        redisTemplate.opsForZSet().add(key, "user1", getTimeStamp());
+        redisTemplate.opsForZSet().add(key, "user2", getTimeStamp());
+        redisTemplate.opsForZSet().add(key, "user3", getTimeStamp());
+
+        // when
+        List<String> participants = roomParticipantRedisService.getParticipants(roomId);
+
+        // then
+        assertThat(participants).isNotNull();
+        assertThat(participants.get(0)).isEqualTo("user1");
+    }
+
+    @DisplayName("유저가 방에 입장한다.")
+    @Test
+    void testAddParticipant() {
+        // given
+        Long roomId = 12345L;
+        Long timestamp = System.currentTimeMillis();
+
+        // when
+        roomParticipantRedisService.addParticipant(roomId, timestamp);
+
+        // then
+        roomParticipantRedisService.getParticipants(roomId);
+    }
+
+    @DisplayName("입장순으로 다음 방장이 될 인원을 가져온다.")
+    @Test
+    void testGetNextHost() {
+        // given
+        Long roomId = 12345L;
+        String key = "room:participants:" + roomId;
+        redisTemplate.opsForZSet().add(key, "user1", getTimeStamp());
+        redisTemplate.opsForZSet().add(key, "user2", getTimeStamp() + 1);
+        redisTemplate.opsForZSet().add(key, "user3", getTimeStamp() + 2);
+
+        redisTemplate.opsForZSet().remove(key, "user1");
+        // when
+        String nextHost = roomParticipantRedisService.getNextHost(roomId);
+
+        // then
+        assertThat(nextHost).isEqualTo("user2");
+    }
+
+    @DisplayName("플레이어를 내보낸다.")
+    @Test
+    void testRemoveParticipant() {
+        // given
+        Long roomId = 12345L;
+        String key = "room:participants:" + roomId;
+        redisTemplate.opsForZSet().add(key, 101L, getTimeStamp());
+        redisTemplate.opsForZSet().add(key, 102L, getTimeStamp() + 1);
+        redisTemplate.opsForZSet().add(key, 103L, getTimeStamp() + 2);
+
+        // when
+        roomParticipantRedisService.removeParticipant(roomId, 103L);
+
+        // then
+        Set<Object> range = redisTemplate.opsForZSet().range(key, 0, -1);
+        assertThat(range).size().isEqualTo(2);
+
+
+    }
+}

--- a/src/test/java/com/example/web2_3_ourtuft_be/room/redis/service/RoomQuizServiceTest.java
+++ b/src/test/java/com/example/web2_3_ourtuft_be/room/redis/service/RoomQuizServiceTest.java
@@ -1,0 +1,46 @@
+package com.example.web2_3_ourtuft_be.room.redis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+class RoomQuizServiceTest {
+    @Autowired private RedisTemplate<String, Object> redisTemplate;
+
+    @Autowired private RoomQuizService roomQuizService;
+
+    Long roomId = 12345L;
+    String quisetKey = "room:quizset:" + roomId;
+    String quizzesKey = "room:quizzes:" + roomId;
+
+    @AfterEach
+    void tearDown() {
+
+        redisTemplate.delete(quisetKey);
+        redisTemplate.delete(quizzesKey);
+    }
+
+    @DisplayName("진행할 퀴즈세트를 정한다.")
+    @Test
+    void testSetQuizSet() {
+        // given
+        Long quizSetId = 10L;
+
+        // when
+        roomQuizService.setQuizSet(roomId, quizSetId);
+
+        // then
+        Object o = redisTemplate.opsForValue().get(quisetKey);
+        assertThat((Long.parseLong(o.toString())));
+    }
+}

--- a/src/test/java/com/example/web2_3_ourtuft_be/room/redis/service/RoomStatusRedisServiceTest.java
+++ b/src/test/java/com/example/web2_3_ourtuft_be/room/redis/service/RoomStatusRedisServiceTest.java
@@ -5,23 +5,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.example.web2_3_ourtuft_be.room.redis.entity.RoomStatus;
 import com.example.web2_3_ourtuft_be.room.redis.repository.RoomStatusRedisRepository;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 class RoomStatusRedisServiceTest {
 
     @Autowired private RoomStatusRedisRepository roomStatusRedisRepository;
-
-    private RoomStatusRedisService roomStatusRedisService;
-
-    @BeforeEach
-    void setUp() {
-        roomStatusRedisService = new RoomStatusRedisService(roomStatusRedisRepository);
-    }
+    @Autowired private RoomStatusRedisService roomStatusRedisService;
 
     @AfterEach
     void tearDown() {
@@ -41,12 +37,12 @@ class RoomStatusRedisServiceTest {
 
         // then
         assertThat(status).isNotNull();
-        assertThat(status).extracting("roomStatus").isEqualTo(roomStatus);
+        assertThat(status).extracting("status").isEqualTo(roomStatus);
     }
 
     @DisplayName("게임시작, 종료 시 RoomStatus를 변경한다. ")
     @Test
-    void test() {
+    void testUpdateRoomStatus() {
         // given
         Long roomId = 20L;
         String roomStatus = "IN_PROGRESS";

--- a/src/test/java/com/example/web2_3_ourtuft_be/room/redis/service/RoomStatusRedisServiceTest.java
+++ b/src/test/java/com/example/web2_3_ourtuft_be/room/redis/service/RoomStatusRedisServiceTest.java
@@ -1,0 +1,63 @@
+package com.example.web2_3_ourtuft_be.room.redis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.web2_3_ourtuft_be.room.redis.entity.RoomStatus;
+import com.example.web2_3_ourtuft_be.room.redis.repository.RoomStatusRedisRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class RoomStatusRedisServiceTest {
+
+    @Autowired private RoomStatusRedisRepository roomStatusRedisRepository;
+
+    private RoomStatusRedisService roomStatusRedisService;
+
+    @BeforeEach
+    void setUp() {
+        roomStatusRedisService = new RoomStatusRedisService(roomStatusRedisRepository);
+    }
+
+    @AfterEach
+    void tearDown() {
+        roomStatusRedisRepository.deleteAll();
+    }
+
+    @DisplayName("방생성시 RoomStatus를 Redis에 저장한다.")
+    @Test
+    void saveRoomStatus() {
+        // given
+        Long roomId = 20L;
+        String roomStatus = "IN_PROGRESS";
+        roomStatusRedisService.saveRoomStatus(roomId, roomStatus);
+
+        // when
+        RoomStatus status = roomStatusRedisRepository.findById(20L).orElse(null);
+
+        // then
+        assertThat(status).isNotNull();
+        assertThat(status).extracting("roomStatus").isEqualTo(roomStatus);
+    }
+
+    @DisplayName("게임시작, 종료 시 RoomStatus를 변경한다. ")
+    @Test
+    void test() {
+        // given
+        Long roomId = 20L;
+        String roomStatus = "IN_PROGRESS";
+        String newRoomStatus = "OPEN";
+        roomStatusRedisService.saveRoomStatus(roomId, roomStatus);
+
+        // when
+        RoomStatus changedRoomStatus =
+                roomStatusRedisService.updateRoomStatus(roomId, newRoomStatus);
+
+        // then
+        assertThat(changedRoomStatus.getStatus()).isEqualTo(newRoomStatus);
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## 📝 PR 설명

테스트를 위해 embedded redis를 적용 하고 싶었으나 , 시간이 많지 않아 로컬에 별도로 redis를 띄우고 
테스트 했습니다. pull로 당기셔서 테스트 원하시면 redis 별도로 설치후 확인 해보셔야 합니다 !

redis config는 기존에 도현님이 pr올리셨던 내용으로 이용해서 변경 사항은 없습니다 !

참여자 목록은 계획시 value 값에 score, Host 여부까지 담으려 했었으나 
그렇게 될 경우 별도의 가공 로직이 들어가야 되어 분리 했습니다 !

redis key 형식을  "도메인:고유ID:서브도메인” 으로 하기로 계획 했었으나
RedisRepository 이용시 Entity에 @RedisHash(value = "room:status:")에는 동적 변수가 들어갈 수 없어
"도메인:서브도메인:고유ID” 형식으로 적용 했습니다!

패키지구조는 일단 어디에 넣을지 몰라서  room > redis 에 넣어놨습니다 .. 

## 🔍 주요 변경사항

- [ ] 대기실 상태 레디스 저장, 변경 
- [ ] 대기실 플레이어  참가, 조회, 강퇴, 입장순 조회 



## 🧪 테스트

- [ ] 단위 테스트 추가/수정
- [ ] 테스트 커버리지 확인
- [ ] 소나클라우드 품질 게이트 통과

## ✅ 체크리스트

- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 코드나 주석이 없나요?
- [ ] 브랜치 네이밍 컨벤션을 따랐나요?
- [ ] 관련 문서를 업데이트했나요?

## 🤝 관련 테스트

- #지라 티켓넘버