### PR TITLE
Feat/fe개발용로그인api

### DIFF
--- a/src/main/java/com/example/web2_3_ourtuft_be/auth/controller/TestController.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/auth/controller/TestController.java
@@ -1,0 +1,53 @@
+package com.example.web2_3_ourtuft_be.auth.controller;
+
+import com.example.web2_3_ourtuft_be.auth.dto.*;
+import com.example.web2_3_ourtuft_be.global.response.GlobalResponse;
+import com.example.web2_3_ourtuft_be.security.util.JwtUtil;
+import com.example.web2_3_ourtuft_be.user.entity.User;
+import com.example.web2_3_ourtuft_be.user.repository.UserRepository;
+import com.example.web2_3_ourtuft_be.user.service.UserFacadeService;
+import com.example.web2_3_ourtuft_be.user.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/test")
+public class TestController {
+    // 프론트엔드 개발용 로그인 컨트롤러 (삭제예정)
+
+    private final UserFacadeService userFacadeService;
+    private final UserService userService;
+    private final JwtUtil jwtUtil;
+
+    public TestController(
+            UserFacadeService userFacadeService,
+            UserService userService,
+            JwtUtil jwtUtil) {
+        this.userFacadeService = userFacadeService;
+        this.userService = userService;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @PostMapping("/user")
+    public ResponseEntity<GlobalResponse<User>> creatUser(@RequestBody CreateUserDto userDto) {
+
+        User user = userFacadeService.registerUserForFE(userDto);
+        return ResponseEntity.ok(GlobalResponse.success(user));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<GlobalResponse<String>> login(@RequestBody LoginDto loginDto) {
+        User user = userService.findUserBySocialId(loginDto.getSocialId());
+        String accessToken =
+                jwtUtil.createJwt(
+                        "access",
+                        user.getId(),
+                        user.getName(),
+                        user.getRole(),
+                        24 * 60 * 60 * 1000L);
+        return ResponseEntity.ok(GlobalResponse.success(accessToken));
+    }
+}

--- a/src/main/java/com/example/web2_3_ourtuft_be/auth/dto/CreateUserDto.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/auth/dto/CreateUserDto.java
@@ -1,0 +1,15 @@
+package com.example.web2_3_ourtuft_be.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class CreateUserDto {
+    // 프론트엔드 개발용 회원가입 DTO (삭제예정)
+    private String providerId;
+    private String name;
+    private String email;
+}

--- a/src/main/java/com/example/web2_3_ourtuft_be/auth/dto/LoginDto.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/auth/dto/LoginDto.java
@@ -1,0 +1,13 @@
+package com.example.web2_3_ourtuft_be.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginDto {
+    // 프론트엔드 개발용 로그인 DTO (삭제예정)
+    private String socialId;
+}

--- a/src/main/java/com/example/web2_3_ourtuft_be/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/global/config/SecurityConfig.java
@@ -32,7 +32,8 @@ public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
     private final CustomOAuth2UserService customOAuth2UserService;
-    private static final String[] authUrls = {"/api/v1/auth/**"};
+    //프론트엔드 개발용 로그인 관련 경로 추가
+    private static final String[] authUrls = {"/api/v1/auth/**", "/api/v1/test/**"};
     private static final String[] allowUrls = {"/api/v1/admin/**"};
 
     @Bean

--- a/src/main/java/com/example/web2_3_ourtuft_be/security/filter/CustomRequestFilter.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/security/filter/CustomRequestFilter.java
@@ -30,14 +30,14 @@ public class CustomRequestFilter extends OncePerRequestFilter {
     protected void doFilterInternal(
             HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-
-        String accessToken = request.getHeader("Authorization");
-
-        if (accessToken == null || request.getRequestURI().contains("/api/v1/auth")) {
+        // 현재 token 가져왔을떄 "Bearer " 문자열이 붙어서 들어옴 -> 인증 실패
+        String token = request.getHeader("Authorization");
+        if (token == null || request.getRequestURI().contains("/api/v1/auth")) {
             filterChain.doFilter(request, response);
             return;
         }
-
+        // token 이 null 일수도 있으므로 여기서 떼주었습니다. 변수명이나 조건문 위치 등등 수정 필요할듯
+        String accessToken = token.replace("Bearer ", "");
         try {
             jwtUtil.isExpired(accessToken);
         } catch (ExpiredJwtException e) {
@@ -52,7 +52,6 @@ public class CustomRequestFilter extends OncePerRequestFilter {
 
             return;
         }
-
         if (!jwtUtil.getCategory(accessToken).equals("access")) {
             response.setContentType("application/json; charset=UTF-8");
 
@@ -65,7 +64,6 @@ public class CustomRequestFilter extends OncePerRequestFilter {
 
             return;
         }
-
         authenticate(accessToken);
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/service/UserFacadeService.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/service/UserFacadeService.java
@@ -1,5 +1,6 @@
 package com.example.web2_3_ourtuft_be.user.service;
 
+import com.example.web2_3_ourtuft_be.auth.dto.CreateUserDto;
 import com.example.web2_3_ourtuft_be.auth.dto.OAuth2Response;
 import com.example.web2_3_ourtuft_be.common.PageResponse;
 import com.example.web2_3_ourtuft_be.item.dto.ItemResponse;
@@ -143,5 +144,17 @@ public class UserFacadeService {
     public PageResponse<ItemResponse> getWishItems(Long userId, Pageable pageable) {
         List<Long> wishItemsId = wishlistItemService.getWishItemIds(userId);
         return itemService.getItemInfoByWishlist(wishItemsId, pageable);
+    }
+
+    // 프론트엔드 개발용 (소셜 구현되면 삭제 예정)
+    @Transactional
+    public User registerUserForFE(CreateUserDto userInfo) {
+        User newUser = userService.createUserForFE(userInfo);
+        Long userId = newUser.getId();
+        profileService.createProfile(userId);
+        memberPointService.createPoint(userId);
+        memberRecordService.createRecord(userId);
+        expService.createExp(userId);
+        return newUser;
     }
 }

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/service/UserService.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/service/UserService.java
@@ -1,9 +1,11 @@
 package com.example.web2_3_ourtuft_be.user.service;
 
+import com.example.web2_3_ourtuft_be.auth.dto.CreateUserDto;
 import com.example.web2_3_ourtuft_be.auth.dto.OAuth2Response;
 import com.example.web2_3_ourtuft_be.global.exception.exceptions.NotFoundException;
 import com.example.web2_3_ourtuft_be.global.exception.messages.NotFoundMessages;
 import com.example.web2_3_ourtuft_be.user.entity.User;
+import com.example.web2_3_ourtuft_be.user.entity.enums.Provider;
 import com.example.web2_3_ourtuft_be.user.entity.enums.Role;
 import com.example.web2_3_ourtuft_be.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -37,5 +39,20 @@ public class UserService {
 
     public User findUserBySocialId(String socialId) {
         return userRepository.findBySocialId(socialId).orElse(null);
+    }
+
+    // 프론트엔드 개발용 (소셜 구현되면 삭제 예정)
+    public User createUserForFE(CreateUserDto userInfo) {
+        User newUser =
+                User.builder()
+                        .email(userInfo.getEmail())
+                        .name(userInfo.getName())
+                        .socialId(userInfo.getProviderId())
+                        .provider(Provider.KAKAO.toString())
+                        .role(Role.ROLE_USER.toString())
+                        .build();
+        userRepository.save(newUser);
+
+        return newUser;
     }
 }


### PR DESCRIPTION
# Pull Request Template

## 📝 PR 설명

- fe개발용로그인api 추가 구현
- 현재 소셜로그인  기능 구현에 제한사항이 많아 (redirecturl 설정 등등) 간편하게 사용가능한 회원 가입, 로그인 api를 만들었습니다.
- 토큰 지속시간은 24시간입니다. (Refresh 없으므로 만료시 로그인 새로 해야함)
- 회원가입시 필드
        String providerId;
        String name;
        String email;
      
- 로그인시 필드 
        String socialId

- 시간도 없고 급해서 컨트롤러에 로직 넣고, 엔티티 그대로 반환했습니다 나중에 수정해놓을게요
- 토큰을 넣어도 401 에러가 나는 이유 -> 토큰을 가져올때, 문자열 처리가 덜 되었음 
- 에러메시지 잘못된 토큰입니다 추가해야할듯 (복호화 실패시 멘트 추가, 기존 에러메세지로는 유추하기가 힘들었습니다...)
- 
## 🔍 주요 변경사항

- [ ] 변경사항 1
- [ ] 변경사항 2
- [ ] 변경사항 3


## 🧪 테스트

- [ ] 단위 테스트 추가/수정
- [ ] 테스트 커버리지 확인
- [ ] 소나클라우드 품질 게이트 통과

## ✅ 체크리스트

- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 코드나 주석이 없나요?
- [ ] 브랜치 네이밍 컨벤션을 따랐나요?
- [ ] 관련 문서를 업데이트했나요?

## 🤝 관련 테스트

- #지라 티켓넘버