### PR TITLE
Feat/data init 기능 추가

### DIFF
--- a/src/main/java/com/example/web2_3_ourtuft_be/global/initializer/ItemInitializer.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/global/initializer/ItemInitializer.java
@@ -31,7 +31,7 @@ public class ItemInitializer implements CommandLineRunner {
             }
 
             // 해당 카테고리 아이템이 없을 경우에만 추가
-            if (itemRepository.countByCategory(category.name()) == 0) {
+            if (itemRepository.countByCategory(category.name()) <= 0) {
                 saveItems(createCategoryItems(category));
             }
         }

--- a/src/main/java/com/example/web2_3_ourtuft_be/global/initializer/ItemInitializer.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/global/initializer/ItemInitializer.java
@@ -25,8 +25,15 @@ public class ItemInitializer implements CommandLineRunner {
     public void run(String... args) throws Exception {
         for (int i = 0; i < 3; i++) {
             Category category = Category.values()[i];
-            saveItem(createDefaultItem(category));
-            saveItems(createCategoryItems(category));
+            // 기본 아이템이 없는 경우에만 추가
+            if (!itemRepository.existsByName(DEFAULT_PREFIX + category.name())) {
+                saveItem(createDefaultItem(category));
+            }
+
+            // 해당 카테고리 아이템이 없을 경우에만 추가
+            if (itemRepository.countByCategory(category.name()) == 0) {
+                saveItems(createCategoryItems(category));
+            }
         }
     }
 

--- a/src/main/java/com/example/web2_3_ourtuft_be/global/initializer/ItemInitializer.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/global/initializer/ItemInitializer.java
@@ -1,0 +1,76 @@
+package com.example.web2_3_ourtuft_be.global.initializer;
+
+import com.example.web2_3_ourtuft_be.item.entity.Item;
+import com.example.web2_3_ourtuft_be.item.entity.enums.Category;
+import com.example.web2_3_ourtuft_be.item.repository.ItemRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ItemInitializer implements CommandLineRunner {
+
+    private static final String S3_URL = "https://team09-bucket.s3.ap-northeast-2.amazonaws.com";
+    private static final String DEFAULT_PREFIX = "default-";
+    private static final String PNG = ".png";
+    private final ItemRepository itemRepository;
+
+    public ItemInitializer(ItemRepository itemRepository) {
+        this.itemRepository = itemRepository;
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        for (int i = 0; i < 3; i++) {
+            Category category = Category.values()[i];
+            saveItem(createDefaultItem(category));
+            saveItems(createCategoryItems(category));
+        }
+    }
+
+    private List<Item> createCategoryItems(Category category) {
+        return IntStream.range(2, 4)
+                .mapToObj(i -> createItem(category, i))
+                .collect(Collectors.toList());
+    }
+
+    private Item createItem(Category category, int index) {
+        return Item.builder()
+                .name(category.name() + index)
+                .category(category.name())
+                .imageUrl(formatImageUrl(category, String.valueOf(index)))
+                .originalPrice(300)
+                .stock(200)
+                .build();
+    }
+
+    private Item createDefaultItem(Category category) {
+        return Item.builder()
+                .name(DEFAULT_PREFIX + category.name())
+                .category(category.name())
+                .imageUrl(formatImageUrl(category, DEFAULT_PREFIX))
+                .originalPrice(300)
+                .stock(200)
+                .build();
+    }
+
+    private String formatImageUrl(Category category, String identifier) {
+        return String.format(
+                "%s/%s/%s%s%s",
+                S3_URL,
+                category.name().toLowerCase(),
+                identifier,
+                category.name().toLowerCase(),
+                PNG);
+    }
+
+    private void saveItem(Item item) {
+        itemRepository.save(item);
+    }
+
+    private void saveItems(List<Item> items) {
+        itemRepository.saveAll(items);
+    }
+}

--- a/src/main/java/com/example/web2_3_ourtuft_be/global/initializer/UserInitializer.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/global/initializer/UserInitializer.java
@@ -1,0 +1,30 @@
+package com.example.web2_3_ourtuft_be.global.initializer;
+
+import com.example.web2_3_ourtuft_be.auth.dto.CreateUserDto;
+import com.example.web2_3_ourtuft_be.user.dto.RewardDto;
+import com.example.web2_3_ourtuft_be.user.service.UserFacadeService;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserInitializer implements CommandLineRunner {
+    private static final String TESTER = "tester";
+    private final UserFacadeService userFacadeService;
+
+    public UserInitializer(UserFacadeService userFacadeService) {
+        this.userFacadeService = userFacadeService;
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        for (int i = 1; i < 4; i++) {
+            createUser(i);
+        }
+    }
+
+    private void createUser(int id) {
+        CreateUserDto createUserDto = new CreateUserDto(TESTER + id, TESTER + id, TESTER + id);
+        userFacadeService.registerUserForFE(createUserDto);
+        userFacadeService.reward((long) id, new RewardDto(100, 5000));
+    }
+}

--- a/src/main/java/com/example/web2_3_ourtuft_be/global/initializer/UserInitializer.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/global/initializer/UserInitializer.java
@@ -2,7 +2,9 @@ package com.example.web2_3_ourtuft_be.global.initializer;
 
 import com.example.web2_3_ourtuft_be.auth.dto.CreateUserDto;
 import com.example.web2_3_ourtuft_be.user.dto.RewardDto;
+import com.example.web2_3_ourtuft_be.user.entity.User;
 import com.example.web2_3_ourtuft_be.user.service.UserFacadeService;
+import com.example.web2_3_ourtuft_be.user.service.UserService;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 
@@ -10,15 +12,20 @@ import org.springframework.stereotype.Component;
 public class UserInitializer implements CommandLineRunner {
     private static final String TESTER = "tester";
     private final UserFacadeService userFacadeService;
+    private final UserService userService;
 
-    public UserInitializer(UserFacadeService userFacadeService) {
+    public UserInitializer(UserFacadeService userFacadeService, UserService userService) {
         this.userFacadeService = userFacadeService;
+        this.userService = userService;
     }
 
     @Override
     public void run(String... args) throws Exception {
         for (int i = 1; i < 4; i++) {
-            createUser(i);
+            User user = userService.findUserBySocialId(TESTER + i);
+            if (user == null) {
+                createUser(i);
+            }
         }
     }
 

--- a/src/main/java/com/example/web2_3_ourtuft_be/item/repository/ItemRepository.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/item/repository/ItemRepository.java
@@ -21,4 +21,8 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     Slice<Item> findAllByIdIn(List<Long> itemIds, Pageable pageable);
 
     List<Item> findByDiscountId(Long discountId);
+
+    boolean existsByName(String name);
+
+    long countByCategory(String category);
 }

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/controller/UserController.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/controller/UserController.java
@@ -133,9 +133,11 @@ public class UserController {
         @ApiResponse(responseCode = "404", description = "포인트가 존재하지 않습니다.")
     })
     @PostMapping("/reward")
-    public ResponseEntity<GlobalResponse<RewardDto>> reward(@RequestBody RewardDto request) {
+    public ResponseEntity<GlobalResponse<RewardDto>> reward(
+            @RequestBody RewardDto request,
+            @AuthenticationPrincipal(expression = "user") User user) {
 
-        RewardDto response = userFacadeService.reward(request);
+        RewardDto response = userFacadeService.reward(user.getId(), request);
         return ResponseEntity.ok(GlobalResponse.success(response));
     }
 }

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/entity/Inventory.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/entity/Inventory.java
@@ -1,5 +1,6 @@
 package com.example.web2_3_ourtuft_be.user.entity;
 
+import com.example.web2_3_ourtuft_be.item.entity.enums.Category;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -20,4 +21,15 @@ public class Inventory {
     private Long itemId;
 
     private String category;
+
+    @Builder
+    private Inventory(Long userId, Long itemId, Category category) {
+        this.userId = userId;
+        this.itemId = itemId;
+        this.category = category.name();
+    }
+
+    public static Inventory create(Long userId, Long itemId, Category category) {
+        return Inventory.builder().userId(userId).itemId(itemId).category(category).build();
+    }
 }

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/entity/MemberProfile.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/entity/MemberProfile.java
@@ -21,15 +21,15 @@ public class MemberProfile extends BaseTime {
     @Column(unique = true)
     private String nickname;
 
-    private String introduction;
+    private String introduction = "안녕하세요";
 
     private Long eyeItemId = 1L;
 
-    private Long mouseItemId = 1L;
+    private Long mouseItemId = 4L;
 
-    private Long skinItemId = 1L;
+    private Long skinItemId = 7L;
 
-    private Long nicknameItemId = 1L;
+    private Long nicknameItemId;
 
     public MemberProfile(Long userId) {
         this.userId = userId;

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/entity/Point.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/entity/Point.java
@@ -7,7 +7,7 @@ import jakarta.persistence.Embeddable;
 
 @Embeddable
 public class Point {
-    private int point;
+    private final int point;
 
     public Point() {
         this.point = 0;

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/service/InventoryService.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/service/InventoryService.java
@@ -49,4 +49,14 @@ public class InventoryService {
 
         return new InventoryItemDto(eyeItems, mouthItems, skinItems, nickColorItems);
     }
+
+    public void registerDefaultItem(Long userId) {
+        List<Inventory> defaultItems =
+                List.of(
+                        Inventory.create(userId, 1L, Category.EYE),
+                        Inventory.create(userId, 4L, Category.MOUTH),
+                        Inventory.create(userId, 7L, Category.SKIN));
+
+        inventoryRepository.saveAll(defaultItems);
+    }
 }

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/service/MemberPointService.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/service/MemberPointService.java
@@ -39,6 +39,7 @@ public class MemberPointService {
         MemberPoint memberPoint = getPoint(userId);
 
         memberPoint.updatePoints(type, amount);
+        memberPointRepository.save(memberPoint);
 
         pointHistoryService.savePointHistory(memberPoint.getId(), amount, type, reason);
     }

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/service/UserFacadeService.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/service/UserFacadeService.java
@@ -154,7 +154,7 @@ public class UserFacadeService {
         User exist = userService.findUserBySocialId(userInfo.getProviderId());
         if (exist != null) {
             throw new DuplicatedException(DuplicatedMessages.EMAIL);
-
+        }
         User newUser = userService.createUserForFE(userInfo);
         Long userId = newUser.getId();
         profileService.createProfile(userId);

--- a/src/main/java/com/example/web2_3_ourtuft_be/user/service/UserFacadeService.java
+++ b/src/main/java/com/example/web2_3_ourtuft_be/user/service/UserFacadeService.java
@@ -29,6 +29,7 @@ public class UserFacadeService {
     private final MemberRecordService memberRecordService;
     private final MemberPointService pointService;
     private final WishlistItemService wishlistItemService;
+    private final InventoryService inventoryService;
 
     @Transactional(readOnly = true)
     public UserInfoResponseDto getUserInfo(Long userId) {
@@ -120,8 +121,7 @@ public class UserFacadeService {
         return newUser;
     }
 
-    public RewardDto reward(RewardDto request) {
-        Long userId = 1L;
+    public RewardDto reward(Long userId, RewardDto request) {
         int exp = expService.increaseExp(userId, request.getExp());
         // TODO: UserId 로직 변경하면서 points 가져오는 부분 중복 제거 예정
         pointService.updatePoints(
@@ -161,6 +161,7 @@ public class UserFacadeService {
         memberPointService.createPoint(userId);
         memberRecordService.createRecord(userId);
         expService.createExp(userId);
+        inventoryService.registerDefaultItem(userId);
         return newUser;
     }
 }


### PR DESCRIPTION
# Pull Request Template

## 📝 PR 설명

- 기본 Item 9가지 데이터 추가
- 테스트용 tester user 계정 3개 추가
- user생성시, 관련 엔티티 데이터들 (프로필, 인벤토리, 포인트 등) 기본 데이터 반영되도록 추가, 수정 

## 🔍 주요 변경사항

- [ ] PointService updates 부분 save 로직 추가 (기존 메서드 사용하느라 변경한 것으로 기존에 작동이 잘 되었는지 확인 필요)
- [ ] 일단 기본 아이템 9가지는 id가 변하지 않는다는 가정 하에, 프로필, 인벤토리 엔티티에 itemId를 직접 지정해두었음, 검토 필요
- [ ] reward API 에서  userId 가져오는 부분 수정


## 🧪 테스트

- [ ] 단위 테스트 추가/수정
- [ ] 테스트 커버리지 확인
- [ ] 소나클라우드 품질 게이트 통과

## ✅ 체크리스트

- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 코드나 주석이 없나요?
- [ ] 브랜치 네이밍 컨벤션을 따랐나요?
- [ ] 관련 문서를 업데이트했나요?

## 🤝 관련 테스트

- #지라 티켓넘버